### PR TITLE
Supply pairs directly to support integers, periods, etc

### DIFF
--- a/lib/transmog.ex
+++ b/lib/transmog.ex
@@ -27,6 +27,24 @@ defmodule Transmog do
       iex> formatted_source
       [%{"b" => %{"a" => "c"}}, %{"b" => %{"a" => "d"}}]
 
+  In order to apply the transformation to special values such as numbers, floats
+  and strings with periods in them then you can supply the path directly and
+  bypass the parser.
+
+  ## Examples
+
+      iex> key_mapping = [{[1], "1"}]
+      iex> source = [%{1 => "a"}]
+      iex> {:ok, formatted_source} = Transmog.format(source, key_mapping)
+      iex> formatted_source
+      [%{"1" => "a"}]
+
+      iex> key_mapping = [{["a.b"], "a_b"}]
+      iex> source = [%{"a.b" => "a"}]
+      iex> {:ok, formatted_source} = Transmog.format(source, key_mapping)
+      iex> formatted_source
+      [%{"a_b" => "a"}]
+
   """
 
   alias Transmog.Matcher

--- a/lib/transmog.ex
+++ b/lib/transmog.ex
@@ -41,7 +41,7 @@ defmodule Transmog do
   @typedoc """
   `key` is the type of valid key parsed in a key mapping.
   """
-  @type key :: atom | binary
+  @type key :: atom | binary | float | non_neg_integer
 
   @typedoc """
   `pair` is the type for a valid pair. A valid pair is a two tuple consisting of
@@ -51,9 +51,14 @@ defmodule Transmog do
 
   @typedoc """
   `raw_pair` is the type for a valid input pair. An input pair following the
-  string format using dot notation.
+  string format using dot notation. Alternatively you could choose to supply the
+  pairs manually. This could be useful if you want to use values that cannot be
+  easily parsed by the parser.
+
+  Some examples would be if you want to use integers, floats or map keys with
+  period characters in them.
   """
-  @type raw_pair :: {binary, binary}
+  @type raw_pair :: {binary | [key], binary | [key]}
 
   @typedoc """
   `result` is the type for the output from `format/2`.

--- a/lib/transmog/matcher.ex
+++ b/lib/transmog/matcher.ex
@@ -21,7 +21,8 @@ defmodule Transmog.Matcher do
 
   """
   @spec find(pairs :: [Transmog.pair()], key :: Transmog.key()) :: Transmog.key()
-  def find(pairs, key) when is_list(pairs) and (is_atom(key) or is_binary(key)) do
+  def find(pairs, key)
+      when is_list(pairs) and (is_atom(key) or is_binary(key) or is_number(key)) do
     case Enum.find(pairs, &pair_matches?(key, &1)) do
       nil -> key
       {[_], [to]} -> to

--- a/lib/transmog/parser.ex
+++ b/lib/transmog/parser.ex
@@ -22,9 +22,13 @@ defmodule Transmog.Parser do
   understood by the formatter. It performs the parse according to the following
   rules:
 
-  1. Each pair must be a two tuple of strings.
+  1. Each pair must be a two tuple of strings or well formed pair.
   2. Each string can use dot notation to represent nested values.
   3. Atoms are represented literally, ie. ":name" for `:name`.
+
+  In special cases you may want to parse values such as numbers, periods,
+  floating point, etc. You can bypass the parser by supplying the paths
+  directly.
 
   ## Examples
 
@@ -35,6 +39,10 @@ defmodule Transmog.Parser do
       iex> pairs = [{":a.b", ":a.:b"}]
       iex> Transmog.Parser.parse(pairs)
       [{[:a, "b"], [:a, :b]}]
+
+      iex> pairs = [{[1, 2], "1.2"}]
+      iex> Transmog.Parser.parse(pairs)
+      [{[1, 2], ["1", "2"]}]
 
   """
   @spec parse(pairs :: [Transmog.raw_pair()]) :: {:ok, [Transmog.pair()]} | error
@@ -70,7 +78,8 @@ defmodule Transmog.Parser do
   def valid?(_), do: false
 
   # Converts a dot notation string into a path list. Atoms will be parsed from
-  # strings if applicable at this stage.
+  # strings if applicable at this stage. If the pair provided is already well
+  # formed then it will be returned as is.
   @spec do_parse(path :: binary | [Transmog.key()]) :: [Transmog.key()]
   defp do_parse(path) when is_list(path), do: path
 

--- a/lib/transmog/parser.ex
+++ b/lib/transmog/parser.ex
@@ -71,8 +71,10 @@ defmodule Transmog.Parser do
 
   # Converts a dot notation string into a path list. Atoms will be parsed from
   # strings if applicable at this stage.
-  @spec from_string(path :: binary) :: [Transmog.key()]
-  defp from_string(path) when is_binary(path) do
+  @spec do_parse(path :: binary | [Transmog.key()]) :: [Transmog.key()]
+  defp do_parse(path) when is_list(path), do: path
+
+  defp do_parse(path) when is_binary(path) do
     path
     |> String.split(".")
     |> Enum.map(&parse_field/1)
@@ -90,8 +92,9 @@ defmodule Transmog.Parser do
   # encountered.
   @spec parse_pair(pair :: Transmog.pair(), pairs :: [Transmog.pair()]) ::
           {:cont, [Transmog.pair()]} | {:halt, error}
-  defp parse_pair({from, to}, pairs) when is_binary(from) and is_binary(to) do
-    {:cont, pairs ++ [{from_string(from), from_string(to)}]}
+  defp parse_pair({from, to}, pairs)
+       when (is_binary(from) or is_list(from)) and (is_binary(to) or is_list(to)) do
+    {:cont, pairs ++ [{do_parse(from), do_parse(to)}]}
   end
 
   defp parse_pair(_, _), do: {:halt, {:error, :invalid_pair}}

--- a/test/transmog/parser_test.exs
+++ b/test/transmog/parser_test.exs
@@ -20,6 +20,15 @@ defmodule Transmog.ParserTest do
 
       assert {:error, :invalid_pair} = Parser.parse(input)
     end
+
+    test "given a pre-defined path, then the path is returned as is" do
+      input = [{[:a, "b"], "a.b"}]
+      expected = [{[:a, "b"], ["a", "b"]}]
+
+      assert {:ok, output} = Parser.parse(input)
+
+      assert output == expected
+    end
   end
 
   describe "valid?/1" do

--- a/test/transmog_test.exs
+++ b/test/transmog_test.exs
@@ -37,5 +37,29 @@ defmodule TransmogTest do
 
       assert Transmog.format(values, pairs) == expected
     end
+
+    test "given a value with an integer key, then the value is mapped correctly" do
+      values = %{1 => "a"}
+      pairs = [{[1], "1"}]
+      expected = {:ok, %{"1" => "a"}}
+
+      assert Transmog.format(values, pairs) == expected
+    end
+
+    test "given a value with a float key, then the value is mapped correctly" do
+      values = %{3.14 => "a"}
+      pairs = [{[3.14], [6.28]}]
+      expected = {:ok, %{6.28 => "a"}}
+
+      assert Transmog.format(values, pairs) == expected
+    end
+
+    test "given a value with a period in the key, then the value is mapped correctly" do
+      values = %{"a.b.c" => "a"}
+      pairs = [{["a.b.c"], "abc"}]
+      expected = {:ok, %{"abc" => "a"}}
+
+      assert Transmog.format(values, pairs) == expected
+    end
   end
 end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our Contributing section?
- [x] Have you checked to ensure there aren't other open
      [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you linted your code locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

---

I've added the option for each key mapping to supply the mapping list directly, bypassing the parser. Maybe you have special key types that we can't support with our current version of the DSL (which may or may not change to support them.) Now you can supply the list directly so that you can work with these values _for now_.

I updated the documentation with some examples of how that would work. This will close #5 and #1.
